### PR TITLE
Don't connect to APNS in tests

### DIFF
--- a/lib/em-apn/client.rb
+++ b/lib/em-apn/client.rb
@@ -5,7 +5,7 @@ module EventMachine
     class Client < EventMachine::Connection
       SANDBOX_GATEWAY    = "gateway.sandbox.push.apple.com"
       PRODUCTION_GATEWAY = "gateway.push.apple.com"
-      PORT = 2195
+      PORT               = 2195
 
       # Create a connection to Apple's push notification gateway
       #
@@ -24,10 +24,6 @@ module EventMachine
         gateway ||= (ENV["APN_ENV"] == "production") ? PRODUCTION_GATEWAY : SANDBOX_GATEWAY
 
         EM.connect(gateway, PORT, self, options)
-      end
-
-      def self.gateway
-        (ENV["APN_ENV"] == "production") ? "gateway.push.apple.com" : "gateway.sandbox.push.apple.com"
       end
 
       def initialize(options = {})

--- a/lib/em-apn/test_helper.rb
+++ b/lib/em-apn/test_helper.rb
@@ -32,10 +32,6 @@ module EventMachine
         alias :deliver_without_testing :deliver
         alias :deliver :deliver_with_testing
 
-        def connect
-          # Nope
-        end
-
         def send_data(data)
           # Nope
         end

--- a/spec/em-apn/client_spec.rb
+++ b/spec/em-apn/client_spec.rb
@@ -24,6 +24,10 @@ describe EventMachine::APN::Client do
     end
 
     context "configuring the gateway" do
+      before do
+        ENV["APN_GATEWAY"] = nil
+      end
+
       let(:options) { {:key => ENV["APN_KEY"], :cert => ENV["APN_CERT"]} }
 
       it "defaults to Apple's sandbox (gateway.sandbox.push.apple.com)" do
@@ -33,14 +37,11 @@ describe EventMachine::APN::Client do
       end
 
       it "uses an environment variable for the gateway host (APN_GATEWAY) if specified" do
-        original_apn_gateway = ENV["APN_GATEWAY"]
         ENV["APN_GATEWAY"] = "localhost"
 
         expected_args = ["localhost", 2195, EM::APN::Client, options]
         EM.should_receive(:connect).with(*expected_args).and_return(client)
         EM::APN::Client.connect.should == client
-
-        ENV["APN_GATEWAY"] = original_apn_gateway
       end
 
       it "switches to the production gateway if APN_ENV is set to 'production'" do
@@ -56,21 +57,15 @@ describe EventMachine::APN::Client do
 
     context "configuring SSL" do
       it "falls back to environment variables for key and cert (APN_KEY and APN_CERT) if they are unspecified" do
-        original_apn_key  = ENV["APN_KEY"]
-        original_apn_cert = ENV["APN_CERT"]
-
         ENV["APN_KEY"]  = "path/to/key.pem"
         ENV["APN_CERT"] = "path/to/cert.pem"
 
-        expected_args = ["gateway.sandbox.push.apple.com", 2195, EM::APN::Client, {
+        expected_args = ["127.0.0.1", 2195, EM::APN::Client, {
           :key  => "path/to/key.pem",
           :cert => "path/to/cert.pem"
         }]
         EM.should_receive(:connect).with(*expected_args).and_return(client)
         EM::APN::Client.connect.should == client
-
-        ENV["APN_KEY"]  = original_apn_key
-        ENV["APN_CERT"] = original_apn_cert
       end
 
       it "key and cert are used to start SSL" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,9 @@ require "em-apn/test_helper"
 
 RSpec.configure do |config|
   config.before(:each) do
-    ENV["APN_KEY"]  = "spec/support/certs/key.pem"
-    ENV["APN_CERT"] = "spec/support/certs/cert.pem"
+    ENV["APN_KEY"]     = "spec/support/certs/key.pem"
+    ENV["APN_CERT"]    = "spec/support/certs/cert.pem"
+    ENV["APN_GATEWAY"] = "127.0.0.1"
 
     EM::APN.logger = Logger.new("/dev/null")
   end


### PR DESCRIPTION
The unit suite was hitting Apple's sandbox servers. This
change defaults the gatway to localhost which allows for
the suite to run while disconnected from the Internet.
- Set APN_GATEWAY environment variable to localhost before each
- Remove unused EM::APN::Client#connect override noop
- Remove unused EM::APN::Client.gateway method
