### PR TITLE
Change push notification size limit from 256 to 2048

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ callbacks can also be set directly to anything that responds to `#call`:
 
 ### Max Payload Size ###
 
-Apple enforces a limit of __256 bytes__ for the __entire payload__.
+Apple enforces a limit of __2048 bytes__ for the __entire payload__.
 
 If you attempt to deliver a notification that exceeds that limit, the library
 will raise an `EM::APN::Notification::PayloadTooLarge` exception.

--- a/lib/em-apn/notification.rb
+++ b/lib/em-apn/notification.rb
@@ -3,7 +3,7 @@
 module EventMachine
   module APN
     class Notification
-      DATA_MAX_BYTES = 256
+      DATA_MAX_BYTES = 2048
       ALERT_KEY = "alert"
 
       class PayloadTooLarge < StandardError; end

--- a/spec/em-apn/notification_spec.rb
+++ b/spec/em-apn/notification_spec.rb
@@ -89,7 +89,7 @@ describe EventMachine::APN::Notification do
 
   describe "#validate!" do
     it "raises PayloadTooLarge error if PAYLOAD_MAX_BYTES exceeded" do
-      notification = EM::APN::Notification.new(token, {:alert => "X" * 512})
+      notification = EM::APN::Notification.new(token, {:alert => "X" * 2050})
 
       lambda {
         notification.validate!
@@ -140,13 +140,13 @@ describe EventMachine::APN::Notification do
   describe "#truncate_alert!" do
     context "when the data size would exceed the APN limit" do
       it "truncates the alert" do
-        notification = EM::APN::Notification.new(token, { "alert" => "X" * 300 })
+        notification = EM::APN::Notification.new(token, { "alert" => "X" * 2050 })
         notification.data.size.should be > EM::APN::Notification::DATA_MAX_BYTES
 
         notification.truncate_alert!
         notification.data.size.should be <= EM::APN::Notification::DATA_MAX_BYTES
         parsed_payload = MultiJson.decode(notification.payload)
-        parsed_payload["aps"]["alert"].size.should == 191
+        parsed_payload["aps"]["alert"].size.should == 1983
       end
 
       it "truncates the alert properly when symbol payload keys are used" do
@@ -156,17 +156,17 @@ describe EventMachine::APN::Notification do
       end
 
       it "truncates the alert properly when it is JSON serialized into a different size" do
-        notification = EM::APN::Notification.new(token, { "alert" => '"' * 300 })
+        notification = EM::APN::Notification.new(token, { "alert" => '"' * 2050 })
         notification.truncate_alert!
         parsed_payload = MultiJson.decode(notification.payload)
-        parsed_payload["aps"]["alert"].size.should == 95
+        parsed_payload["aps"]["alert"].size.should == 991
       end
 
       it "truncates the alert properly for multi-byte Unicode characters" do
-        notification = EM::APN::Notification.new(token, { "alert" => [57352].pack('U') * 500 })
+        notification = EM::APN::Notification.new(token, { "alert" => [57352].pack('U') * 2050 })
         notification.truncate_alert!
         parsed_payload = MultiJson.decode(notification.payload)
-        parsed_payload["aps"]["alert"].size.should == 63
+        parsed_payload["aps"]["alert"].size.should == 661
       end
     end
 


### PR DESCRIPTION
This increases the push notification size limit to 2kb, as described here: http://devstreaming.apple.com/videos/wwdc/2014/713xx1il4h4ur9c/713/713_whats_new_in_ios_notifications.pdf

These changes are now live, and are backward compatible with older versions of iOS.
